### PR TITLE
Update selenium workflow env support

### DIFF
--- a/.github/workflows/playground_selenium.yaml
+++ b/.github/workflows/playground_selenium.yaml
@@ -2,12 +2,25 @@ name: Playground Selenium Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      env:
+        type: choice
+        description: "Target environment"
+        required: true
+        default: "dev"
+        options:
+          - "dev"
+          - "qa"
+          - "test"
+          - "main"
   schedule:
     - cron: "0 6 * * *"
 
 jobs:
   selenium-run:
     runs-on: ubuntu-latest
+    env:
+      ENV: ${{ github.event.inputs.env || 'dev' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,11 +38,23 @@ jobs:
           node-version: 22.15
       - name: Yarn install
         run: yarn install
+      - name: Set environment
+        run: sed -i "s/^net = .*/net = $ENV/" packages/playground/tests/frontend_selenium/Config.ini
+      - name: Display test target
+        run: |
+          if [ "$ENV" = "dev" ]; then
+            echo "Running against locally built dashboard"
+          else
+            echo "Running against URLs defined for '$ENV' network"
+          fi
       - name: Lerna Build
+        if: ${{ env.ENV == 'dev' }}
         run: yarn lerna run build
       - name: Yarn Serve
+        if: ${{ env.ENV == 'dev' }}
         run: make run project=playground &
       - name: Wait for localhost
+        if: ${{ env.ENV == 'dev' }}
         run: sleep 60
       - name: Run tests
         working-directory: ./packages/playground/tests/frontend_selenium
@@ -38,4 +63,10 @@ jobs:
           TFCHAIN_NODE_MNEMONICS: ${{ secrets.TFCHAIN_NODE_MNEMONICS }}
           STELLAR_ADDRESS: ${{ secrets.STELLAR_ADDRESS }}
           EMAIL: ${{ secrets.EMAIL }}
-        run: python -m pytest -v
+        run: python -m pytest -v --html=report.html
+      - name: Upload test report
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: selenium-report-${{ env.ENV }}
+          path: packages/playground/tests/frontend_selenium/report.html

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -63,6 +63,14 @@ On **Pull Request**, and **Push** to development branch that has changes in the 
 
 On **Release** published: It will build and push a new docker image based on project release tag.
 
+### [Playground Selenium](/.github/workflows/playground_selenium.yaml)
+
+Runs daily and can also be triggered manually. When triggered manually you can
+select one of `dev`, `qa`, `test` or `main` environments. If `dev` is selected
+the workflow builds and serves the dashboard locally before running the tests;
+otherwise it runs the tests against the URLs baked into the repository for the
+selected network.
+
 ## Threefold UI
 
 ### [Build](/.github/workflows/threefold_ui_build.yaml)

--- a/packages/playground/tests/frontend_selenium/requirements.txt
+++ b/packages/playground/tests/frontend_selenium/requirements.txt
@@ -4,3 +4,4 @@ webdriver_manager==4.0.2
 requests==2.32.3
 pyvirtualdisplay==3.0
 pyperclip==1.9.0
+pytest-html


### PR DESCRIPTION
## Summary
- allow selecting environment when manually running selenium workflow
- skip dashboard build steps unless running locally
- generate HTML test report and upload it
- add pytest-html to selenium test requirements
- document selenium workflow behaviour

## Testing
- `yarn check-prettier` *(fails: package not in lockfile)*
- `yarn install --immutable` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684fb663f1b4832cb557608f7b827421